### PR TITLE
Removed nmea_msgs from ridgeback_base/CMakeLists.txt

### DIFF
--- a/ridgeback_base/CMakeLists.txt
+++ b/ridgeback_base/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(ridgeback_base)
 
 find_package(catkin REQUIRED COMPONENTS
-  controller_manager diagnostic_updater geometry_msgs hardware_interface puma_motor_driver puma_motor_msgs nmea_msgs
+  controller_manager diagnostic_updater geometry_msgs hardware_interface puma_motor_driver puma_motor_msgs
   realtime_tools roscpp rosserial_server sensor_msgs std_msgs teleop_twist_joy
   topic_tools)
 find_package(Boost REQUIRED COMPONENTS thread chrono)


### PR DESCRIPTION
The dependency `nmea_msgs` has been removed from `ridgeback_base/package.xml` in acc534493f1582f9510d12ef778d3ca1c71478bb, but not from `CMakeLists.txt`. As a consequence catkin complains about a missing package and rosdep would not install it without the removed declaration in `package.xml`:

``` cmake
-- catkin 0.6.18
CMake Warning at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:76 (find_package):
  Could not find a package configuration file provided by "nmea_msgs" with
  any of the following names:

    nmea_msgsConfig.cmake
    nmea_msgs-config.cmake

  Add the installation prefix of "nmea_msgs" to CMAKE_PREFIX_PATH or set
  "nmea_msgs_DIR" to a directory containing one of the above files.  If
  "nmea_msgs" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


CMake Error at /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
  Could not find a package configuration file provided by "nmea_msgs" with
  any of the following names:

    nmea_msgsConfig.cmake
    nmea_msgs-config.cmake

  Add the installation prefix of "nmea_msgs" to CMAKE_PREFIX_PATH or set
  "nmea_msgs_DIR" to a directory containing one of the above files.  If
  "nmea_msgs" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  CMakeLists.txt:4 (find_package)


-- Could not find the required component 'nmea_msgs'. The following CMake error indicates that you either need to install the package with the same name or change your environment so that it can be found.
-- Configuring incomplete, errors occurred!
```
