### PR TITLE
[ridgeback_bringup] Removed connman config.

### DIFF
--- a/ridgeback_bringup/scripts/install
+++ b/ridgeback_bringup/scripts/install
@@ -21,12 +21,7 @@ class RidgebackExtras(robot_upstart.providers.Generic):
             can_conf_contents = f.read()
         with open(find_in_workspaces(project="ridgeback_bringup", path="can-udp-bridge.sh")[0]) as f:
             can_sh_contents = f.read()
-        return { "/etc/connman/main.conf": {
-                "content": """[General]
-NetworkInterfaceBlacklist=eth,br,en
-PreferredTechnologies=wifi""",
-                "mode": 0o644
-            },
+        return { 
             "/lib/systemd/system/can-udp-bridge.service": {
                 "content": can_conf_contents,
                 "mode": 0o644


### PR DESCRIPTION
Removing comman since in Melodic, Ridgeback uses `wicd-cures`.