### PR TITLE
Change the can-udp-bringup to use ip instead of ifconfig

### DIFF
--- a/ridgeback_bringup/scripts/can-udp-bridge.sh
+++ b/ridgeback_bringup/scripts/can-udp-bridge.sh
@@ -3,6 +3,6 @@ socat udp4-datagram:192.168.131.2:11412,bind=:11412,range=192.168.131.1/24 pty,l
 sleep 1
 slcand -o -c -F -s8 /dev/ttycan0 can0 &
 sleep 1
-ip link set can0 txqueuelen 200
+ip link set can0 txqueuelen 100
 sleep 1
 ip link set dev can0 up

--- a/ridgeback_bringup/scripts/can-udp-bridge.sh
+++ b/ridgeback_bringup/scripts/can-udp-bridge.sh
@@ -3,6 +3,6 @@ socat udp4-datagram:192.168.131.2:11412,bind=:11412,range=192.168.131.1/24 pty,l
 sleep 1
 slcand -o -c -F -s8 /dev/ttycan0 can0 &
 sleep 1
-ifconfig can0 txqueuelen 100
+ip link set can0 txqueuelen 200
 sleep 1
-ifconfig can0 up
+ip link set dev can0 up

--- a/ridgeback_bringup/scripts/can-udp-bridge.sh
+++ b/ridgeback_bringup/scripts/can-udp-bridge.sh
@@ -5,4 +5,4 @@ slcand -o -c -F -s8 /dev/ttycan0 can0 &
 sleep 1
 ip link set can0 txqueuelen 100
 sleep 1
-ip link set dev can0 up
+ip link set can0 up


### PR DESCRIPTION
Untested on an actual Ridgeback yet. But with the recent change to netplan and removal of the ifupdown package from Melodic and Noetic, I suspect we'll need to make this change.