### PR TITLE
Add dependency for ridgeback_tests

### DIFF
--- a/ridgeback_robot/package.xml
+++ b/ridgeback_robot/package.xml
@@ -17,6 +17,7 @@
 
   <exec_depend>ridgeback_bringup</exec_depend>
   <exec_depend>ridgeback_firmware</exec_depend>
+  <exec_depend>ridgeback_tests</exec_depend>
 
   <export>
     <metapackage />


### PR DESCRIPTION
This PR should only be merged once the test package is released.